### PR TITLE
Publish all stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+/.idea

--- a/src/Console/Publish/PublishStubs.php
+++ b/src/Console/Publish/PublishStubs.php
@@ -4,6 +4,7 @@ namespace Creativeorange\LaravelStubs\Console\Publish;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
 use Symfony\Component\Console\Input\InputOption;
 
 class PublishStubs extends Command
@@ -40,21 +41,11 @@ class PublishStubs extends Command
     public function handle()
     {
 
-        if (! is_dir($stubsPath = $this->laravel->basePath('stubs'))) {
+        if (!is_dir($stubsPath = $this->laravel->basePath('stubs'))) {
             (new Filesystem)->makeDirectory($stubsPath);
         }
 
-        $files = [
-            __DIR__.'/../../stubs/interface.stub' => $stubsPath.'/interface.stub',
-            __DIR__.'/../../stubs/trait.stub' => $stubsPath.'/trait.stub',
-            __DIR__.'/../../stubs/trait-boot.stub' => $stubsPath.'/trait-boot.stub',
-        ];
-
-        foreach ($files as $from => $to) {
-            if (! file_exists($to) || $this->option('force')) {
-                file_put_contents($to, file_get_contents($from));
-            }
-        }
+        File::copyDirectory(__DIR__.'/../../stubs/', $stubsPath);
 
         return $this->info('Stubs published successfully.');
     }

--- a/src/Console/Publish/PublishStubs.php
+++ b/src/Console/Publish/PublishStubs.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputOption;
 
-class PubishStubs extends Command
+class PublishStubs extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/LaravelStubsServiceProvider.php
+++ b/src/LaravelStubsServiceProvider.php
@@ -20,7 +20,7 @@ class LaravelStubsServiceProvider extends ServiceProvider
                 Console\Make\MakeInterface::class,
                 Console\Make\MakeViewComposer::class,
                 /** Publish */
-                Console\Publish\PubishStubs::class,
+                Console\Publish\PublishStubs::class,
                 /** Run */
                 Console\Run\RunFactory::class,
             ]);


### PR DESCRIPTION
With this change basically two things are changed:

- Typo removed in the publish stubs classname. 
- The copy stubs method changed to copy entire directory